### PR TITLE
melhora a exibição de erros para o cliente e do log da aplicação

### DIFF
--- a/lib/routes/error-router.ts
+++ b/lib/routes/error-router.ts
@@ -13,9 +13,9 @@ export class ErrorHandler {
         if ( err instanceof APIError ) {
           _err = err
         } else {
-          _err = new APIError( err, err.status || err.statusCode || 500, null )
+          _err = new APIError( err.message || err, err.status || err.statusCode || 500, null, err.stack )
         }
-        return res.status( _err.statusCode ).json( _err )
+        return res.status( _err.statusCode ).json( _err.output )
       } )
     } else {
 			/**
@@ -27,9 +27,9 @@ export class ErrorHandler {
         if ( err instanceof APIError ) {
           _err = err
         } else {
-          _err = new APIError( err, err.status || err.statusCode || 500, null )
+          _err = new APIError( err.message || err, err.status || err.statusCode || 500, null, err.stack )
         }
-        return res.status( _err.statusCode ).json( _err )
+        return res.status( _err.statusCode ).json( _err.output )
       } )
     }
     return app

--- a/lib/services/api-error.ts
+++ b/lib/services/api-error.ts
@@ -7,10 +7,13 @@ export class APIError extends Error implements IError {
   objectResponse: Object
   private error: Boom.BoomError
 
-  constructor (message: string, statusCode: number, objectResponse?: Object) {
+  constructor (message: string, statusCode: number, objectResponse?: Object, originalStack?: string) {
     super(message)
     this.statusCode = statusCode
     this.objectResponse = objectResponse
+    if (originalStack) {
+      this.stack = originalStack
+    }
     // this.definedBoomError()
     this.showError()
   }


### PR DESCRIPTION
Para melhorar a exibição para o cliente foi utilizado a propriedade output do APIError na rota de erros.
Para melhorar a callstack, foi passada no construtor do APIError a callstack do erro original.
Favor conferir testes e a implicação disso no restante da lib.
closes #33 
closes #29 